### PR TITLE
Add comparison notebook for classic vs M1 scattering

### DIFF
--- a/demonstrations/classic_vs_m1_scattering.ipynb
+++ b/demonstrations/classic_vs_m1_scattering.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b413cdaa",
+   "metadata": {},
+   "source": [
+    "# Classic vs M1 Scattering\n",
+    "This notebook compares traditional relativistic scattering with the Momentum-First (M1) formulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7bb43a40",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-07T21:00:26.839607Z",
+     "iopub.status.busy": "2025-08-07T21:00:26.839325Z",
+     "iopub.status.idle": "2025-08-07T21:00:26.846553Z",
+     "shell.execute_reply": "2025-08-07T21:00:26.845650Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "sys.path.insert(0, os.path.abspath('..'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53e9280a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-07T21:00:26.848820Z",
+     "iopub.status.busy": "2025-08-07T21:00:26.848611Z",
+     "iopub.status.idle": "2025-08-07T21:00:27.555694Z",
+     "shell.execute_reply": "2025-08-07T21:00:27.554982Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from src import ConcreteParticle, ElasticScatteringExperiment, ScatteringComparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fc288614",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-07T21:00:27.558173Z",
+     "iopub.status.busy": "2025-08-07T21:00:27.557811Z",
+     "iopub.status.idle": "2025-08-07T21:00:27.579502Z",
+     "shell.execute_reply": "2025-08-07T21:00:27.578648Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(           A_before  B_before  Total (Before)   A_after   B_after  \\\n",
+       " Component                                                           \n",
+       " px              0.0       0.0             0.0  0.855041 -0.855041   \n",
+       " py              0.0       0.0             0.0  0.000000  0.000000   \n",
+       " pz              4.0       0.0             4.0 -0.855041  4.855041   \n",
+       " Energy          5.0       6.0            11.0  3.234531  7.765469   \n",
+       " \n",
+       "            Total (After)       Balance  \n",
+       " Component                               \n",
+       " px                   0.0  0.000000e+00  \n",
+       " py                   0.0  0.000000e+00  \n",
+       " pz                   4.0  0.000000e+00  \n",
+       " Energy              11.0  2.803640e-09  ,\n",
+       "            A_before  B_before  Total (Before)   A_after    B_after  \\\n",
+       " Component                                                            \n",
+       " x+              5.0       6.0            11.0  2.807010   8.192990   \n",
+       " x-              5.0       6.0            11.0  3.662051   7.337949   \n",
+       " y+              5.0       6.0            11.0  3.234531   7.765469   \n",
+       " y-              5.0       6.0            11.0  3.234531   7.765469   \n",
+       " z+              3.0       6.0             9.0  3.662051   5.337949   \n",
+       " z-              7.0       6.0            13.0  2.807010  10.192990   \n",
+       " \n",
+       "            Total (After)       Balance  \n",
+       " Component                               \n",
+       " x+                  11.0  2.803640e-09  \n",
+       " x-                  11.0  2.803640e-09  \n",
+       " y+                  11.0  2.803640e-09  \n",
+       " y-                  11.0  2.803640e-09  \n",
+       " z+                   9.0  2.803640e-09  \n",
+       " z-                  13.0  2.803640e-09  )"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "particle_A = ConcreteParticle(m0=3, bosic_momentum=np.array([0, 0, 4]), c=1.0)\n",
+    "particle_B = ConcreteParticle(m0=6, bosic_momentum=np.array([0, 0, 0]), c=1.0)\n",
+    "escape_direction = np.array([0.70710678, 0, -0.70710678])\n",
+    "experiment = ElasticScatteringExperiment(particle_A, particle_B, escape_direction)\n",
+    "comparison = ScatteringComparison(experiment)\n",
+    "trad_df, m1_df = comparison.tables()\n",
+    "trad_df, m1_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5b8f808a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-07T21:00:27.581933Z",
+     "iopub.status.busy": "2025-08-07T21:00:27.581720Z",
+     "iopub.status.idle": "2025-08-07T21:00:27.588309Z",
+     "shell.execute_reply": "2025-08-07T21:00:27.587630Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "comparison.verify()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -13,10 +13,12 @@ The main classes exposed at the package level are:
 
 from .particle import Particle, ConcreteParticle
 from .elastic_scattering import ElasticScatteringExperiment
+from .comparison import ScatteringComparison
 
 # Define the public API of the 'src' package.
 __all__ = [
     "Particle",
     "ConcreteParticle",
     "ElasticScatteringExperiment",
+    "ScatteringComparison",
 ]

--- a/src/comparison.py
+++ b/src/comparison.py
@@ -1,0 +1,140 @@
+"""Utility class for comparing standard and Momentum-First scattering results.
+
+This module provides the :class:`ScatteringComparison` class, which wraps an
+:class:`~src.elastic_scattering.ElasticScatteringExperiment` and generates
+conservation tables for both the traditional relativistic formulation and the
+Momentum-First (M1) framework.  It also offers a convenience method to verify
+that the balances in both tables vanish, confirming conservation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+from .elastic_scattering import ElasticScatteringExperiment
+
+
+@dataclass
+class ScatteringComparison:
+    """Generate and verify conservation tables for an experiment.
+
+    Parameters
+    ----------
+    experiment:
+        The :class:`ElasticScatteringExperiment` to analyse.  The experiment
+        will be solved lazily when tables are requested.
+    """
+
+    experiment: ElasticScatteringExperiment
+
+    def tables(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        """Return conservation tables for standard and M1 formulations.
+
+        Returns
+        -------
+        Tuple[pandas.DataFrame, pandas.DataFrame]
+            Two data frames corresponding to the traditional (energy and vector
+            momentum) and the Momentum-First directional momentum components.
+        """
+        if not self.experiment.solved:
+            self.experiment.solve()
+
+        # --- Traditional table ---
+        states = {
+            "A_before": self.experiment.initial_A,
+            "B_before": self.experiment.initial_B,
+            "A_after": self.experiment.final_A,
+            "B_after": self.experiment.final_B,
+        }
+
+        trad_data = []
+        components = ["px", "py", "pz", "Energy"]
+        for i, comp_name in enumerate(components):
+            row = {"Component": comp_name}
+            val_A_before = (
+                states["A_before"].energy
+                if comp_name == "Energy"
+                else states["A_before"].bosic_momentum[i]
+            )
+            val_B_before = (
+                states["B_before"].energy
+                if comp_name == "Energy"
+                else states["B_before"].bosic_momentum[i]
+            )
+            total_before = val_A_before + val_B_before
+
+            val_A_after = (
+                states["A_after"].energy
+                if comp_name == "Energy"
+                else states["A_after"].bosic_momentum[i]
+            )
+            val_B_after = (
+                states["B_after"].energy
+                if comp_name == "Energy"
+                else states["B_after"].bosic_momentum[i]
+            )
+            total_after = val_A_after + val_B_after
+
+            row.update(
+                {
+                    "A_before": val_A_before,
+                    "B_before": val_B_before,
+                    "Total (Before)": total_before,
+                    "A_after": val_A_after,
+                    "B_after": val_B_after,
+                    "Total (After)": total_after,
+                    "Balance": total_before - total_after,
+                }
+            )
+            trad_data.append(row)
+
+        trad_df = pd.DataFrame(trad_data).set_index("Component")
+
+        # --- Momentum-First table ---
+        states_m = {
+            "A_before": self.experiment.initial_A.directional_components,
+            "B_before": self.experiment.initial_B.directional_components,
+            "A_after": self.experiment.final_A.directional_components,
+            "B_after": self.experiment.final_B.directional_components,
+        }
+
+        mfirst_data = []
+        components_m = list(states_m["A_before"].keys())
+        for comp_name in components_m:
+            row = {"Component": comp_name}
+            val_A_before = states_m["A_before"][comp_name]
+            val_B_before = states_m["B_before"][comp_name]
+            total_before = val_A_before + val_B_before
+
+            val_A_after = states_m["A_after"][comp_name]
+            val_B_after = states_m["B_after"][comp_name]
+            total_after = val_A_after + val_B_after
+
+            row.update(
+                {
+                    "A_before": val_A_before,
+                    "B_before": val_B_before,
+                    "Total (Before)": total_before,
+                    "A_after": val_A_after,
+                    "B_after": val_B_after,
+                    "Total (After)": total_after,
+                    "Balance": total_before - total_after,
+                }
+            )
+            mfirst_data.append(row)
+
+        mfirst_df = pd.DataFrame(mfirst_data).set_index("Component")
+        mfirst_df = mfirst_df.reindex(["x+", "x-", "y+", "y-", "z+", "z-"])
+
+        return trad_df, mfirst_df
+
+    def verify(self, atol: float = 1e-8) -> bool:
+        """Check that both conservation tables balance to zero within tolerance."""
+        trad_df, mfirst_df = self.tables()
+        ok_trad = np.allclose(trad_df["Balance"].values, 0, atol=atol)
+        ok_mfirst = np.allclose(mfirst_df["Balance"].values, 0, atol=atol)
+        return bool(ok_trad and ok_mfirst)

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,25 @@
+"""Tests for the ScatteringComparison helper class."""
+
+import numpy as np
+
+from src import ConcreteParticle, ElasticScatteringExperiment, ScatteringComparison
+
+
+P_A_INITIAL = ConcreteParticle(m0=3, bosic_momentum=np.array([0, 0, 4]), c=1.0)
+P_B_INITIAL = ConcreteParticle(m0=6, bosic_momentum=np.array([0, 0, 0]), c=1.0)
+ESCAPE_DIR = np.array([0.70710678, 0, -0.70710678])
+
+
+def test_tables_and_verification():
+    experiment = ElasticScatteringExperiment(P_A_INITIAL, P_B_INITIAL, ESCAPE_DIR)
+    comparison = ScatteringComparison(experiment)
+    trad_df, mfirst_df = comparison.tables()
+
+    # Expect four rows for traditional and six for M1 tables
+    assert list(trad_df.index) == ["px", "py", "pz", "Energy"]
+    assert list(mfirst_df.index) == ["x+", "x-", "y+", "y-", "z+", "z-"]
+
+    # Verification should pass with zero balances
+    assert np.allclose(trad_df["Balance"].values, 0)
+    assert np.allclose(mfirst_df["Balance"].values, 0)
+    assert comparison.verify()


### PR DESCRIPTION
## Summary
- add `ScatteringComparison` helper to generate traditional and Momentum-First conservation tables and verify them
- expose the new helper and create a notebook demonstrating classic vs M1 scattering
- cover comparison logic with unit tests

## Testing
- `jupyter nbconvert --to notebook --execute --inplace demonstrations/classic_vs_m1_scattering.ipynb`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689512aa8f34832d95542471b0f2319a